### PR TITLE
Update spi_reg.sv

### DIFF
--- a/src/spi/spi_reg.sv
+++ b/src/spi/spi_reg.sv
@@ -100,7 +100,7 @@ module spi_reg #(
         end
       end
       STATE_ADDR : begin
-        if (rx_buffer_counter == 4'd8) begin
+        if (buffer_counter == 4'd8) begin
           sample_addr = 1'b1;
           next_state = STATE_CMD;
         end else if (eof == 1'b1) begin
@@ -117,7 +117,7 @@ module spi_reg #(
         end
       end
       STATE_RX_DATA : begin
-        if (rx_buffer_counter == 4'd8) begin
+        if (buffer_counter == 4'd8) begin
           sample_data = 1'b1;
           next_state = STATE_IDLE;
         end else if (eof == 1'b1) begin
@@ -125,9 +125,9 @@ module spi_reg #(
         end
       end
       STATE_TX_DATA : begin
-        if (tx_buffer_counter == 4'd0) begin
+        if (buffer_counter == 4'd0) begin
           tx_buffer_load = 1'b1;
-        end else if (tx_buffer_counter == 4'd8) begin
+        end else if (buffer_counter == 4'd8) begin
           next_state = STATE_IDLE;
         end else if (eof == 1'b1) begin
           next_state = STATE_IDLE;
@@ -155,19 +155,19 @@ module spi_reg #(
     end
   end
 
-  // RX General counter
-  logic [3:0] rx_buffer_counter;
+  // General counter
+  logic [3:0] buffer_counter;
 
   // RX Buffer Counter
   always_ff @(negedge(rstb) or posedge(clk)) begin
     if (!rstb) begin
-      rx_buffer_counter <= '0;
+      buffer_counter <= '0;
     end else begin
       if (ena == 1'b1) begin
-        if (rx_buffer_counter == 4'd8) begin
-          rx_buffer_counter <= '0;
+        if (buffer_counter == 4'd8) begin
+          buffer_counter <= '0;
         end else if (spi_data_sample == 1'b1) begin
-          rx_buffer_counter <= rx_buffer_counter + 1'b1;
+          buffer_counter <= buffer_counter + 1'b1;
         end
       end
     end
@@ -211,24 +211,6 @@ module spi_reg #(
       end
     end
   end
-
-  // TX General counter
-  logic [3:0] tx_buffer_counter;
-    
-  // TX Buffer counter
-  always_ff @(negedge(rstb) or posedge(clk)) begin
-    if (!rstb) begin
-      tx_buffer_counter <= '0;
-    end else begin
-      if (ena == 1'b1) begin
-        if (tx_buffer_counter == 4'd8) begin
-          tx_buffer_counter <= '0;
-        end else if (spi_data_sample == 1'b1) begin
-          tx_buffer_counter <= tx_buffer_counter + 1'b1;
-        end
-      end
-    end
-  end 
 
   // TX Buffer
   logic [REG_W-1:0] tx_buffer;


### PR DESCRIPTION
Small optimization. RX and TX buffer counter are mutually exclusive, so one general counter is enough.
This saves 4 DFF and improve tile utilization ratio.