### PR TITLE
bump pytest version to 8.4.1 / Update requirements.txt

### DIFF
--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -1,2 +1,2 @@
-pytest==8.3.4
+pytest==8.4.1
 cocotb==1.9.2


### PR DESCRIPTION
This old pytest version (8.4.3) is in conflict with the version from https://github.com/TinyTapeout/tt-support-tools, preventing to start the docker dev container.

I locally tested the change and the tests run fine with the new version (8.4.1).